### PR TITLE
Add devcontainer template for hackathon authors

### DIFF
--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -6,14 +6,13 @@
 // 2. Uncomment and update "workspaceFolder" and "workspaceMount" with your hack's folder name
 // 3. Add any additional features or extensions specific to your hackathon
 //
-// The following two properties should be uncommented and customized per hack:
-//   "workspaceFolder": "/workspace/XXX-HackathonName/Student/Resources",
-//   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-//
 {
   // Update "name" with your hack's number and name (e.g., "042-SAPOnAzure")
   "name": "xxx-HackName",
   "image": "mcr.microsoft.com/devcontainers/universal:2",
+  // Uncomment and update the following two properties with your hack's folder name:
+  // "workspaceFolder": "/workspace/XXX-HackathonName/Student/Resources",
+  // "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "hostRequirements": {
     "cpus": 2
   },

--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -11,8 +11,12 @@
 //   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
 //
 {
-  "name": "What The Hack - Hackathon Template",
+  // Update "name" with your hack's number and name (e.g., "042-SAPOnAzure")
+  "name": "xxx-HackName",
   "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "hostRequirements": {
+    "cpus": 2
+  },
   "features": {
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/azure/azure-dev/azd:latest": {},

--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -35,6 +35,10 @@
         "github.copilot",
         "github.copilot-chat"
       ]
+    },
+    // Add files here that should auto-open when a Codespace launches (e.g., "Student/Challenge-00.md")
+    "codespaces": {
+      "openFiles": []
     }
   }
 }

--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -1,0 +1,36 @@
+// This is a template devcontainer.json for What The Hack hackathons.
+// It provides a baseline configuration for GitHub Codespaces and VS Code Dev Containers.
+//
+// Instructions for hackathon authors:
+// 1. Copy this file to your hack's .devcontainer folder as devcontainer.json
+// 2. Uncomment and update "workspaceFolder" and "workspaceMount" with your hack's folder name
+// 3. Add any additional features or extensions specific to your hackathon
+//
+// The following two properties should be uncommented and customized per hack:
+//   "workspaceFolder": "/workspace/XXX-HackathonName/Student/Resources",
+//   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+//
+{
+  "name": "What The Hack - Hackathon Template",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/azure/azure-dev/azd:latest": {},
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "kubectl": "latest",
+      "helm": "none",
+      "minikube": "none"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-bicep",
+        "ms-python.python",
+        "github.copilot",
+        "github.copilot-chat"
+      ]
+    }
+  }
+}

--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -35,7 +35,7 @@
         "github.copilot-chat"
       ]
     },
-    // Add files here that should auto-open when a Codespace launches (e.g., "Student/Challenge-00.md")
+    // Add files here that should auto-open when a Codespace launches (e.g., "Student/Resources/README.md")
     "codespaces": {
       "openFiles": []
     }


### PR DESCRIPTION
Hackathon authors currently need to build devcontainer configurations from scratch, leading to inconsistency across hacks and a steeper onboarding curve. This PR adds a baseline template they can copy and customize.

## What this adds

A new `000-HowToHack/devcontainerTEMPLATE.json` file that provides a starting point for GitHub Codespaces and VS Code Dev Containers with:

- **Common features**: Azure CLI, Azure Developer CLI, Python, kubectl
- **VS Code extensions**: Bicep, Python, GitHub Copilot, GitHub Copilot Chat
- **Host requirements**: 2 CPUs minimum
- **Codespaces openFiles**: empty array with guidance on what to populate
- **Commented-out workspace properties**: `workspaceFolder` and `workspaceMount` placed inline where authors uncomment and customize them with their hack's folder name

## How authors use it

1. Copy the file into their hack's `.devcontainer/` folder as `devcontainer.json`
2. Update the `name` property with their hack number and name
3. Uncomment and set `workspaceFolder` and `workspaceMount` with their hack's path
4. Add any hack-specific features or extensions

This template is also designed to be consumed by a future GitHub Action that scaffolds new hacks and programmatically updates the placeholder values.