### PR TITLE
Add Codespace configuration option to Create New Hack action

### DIFF
--- a/.github/workflows/create-new-hack.yml
+++ b/.github/workflows/create-new-hack.yml
@@ -12,6 +12,10 @@ on:
         description: The number of challenges you want (note that it is better to auto-generate more challenges than you think you will need, you can always delete the files later)
         required: true
         default: '3'
+      includeCodespace:
+        description: Include a GitHub Codespace configuration?
+        type: boolean
+        default: false
 jobs:
   createNewWhatTheHackTemplate:
     runs-on: ubuntu-latest
@@ -27,10 +31,18 @@ jobs:
           git config user.email "<>"
           git checkout -b ${{ env.BRANCH_NAME }}
       - name: Generate WhatTheHack template stubs
-        run: ${{ github.workspace }}/.github/workflows/create-wth-template.sh -p ${{ github.workspace }} -c ${{ github.event.inputs.numberOfChallenges}} -n ${{ github.event.inputs.hackName }} -v -d
+        run: |
+          CODESPACE_FLAG=""
+          if [ "${{ github.event.inputs.includeCodespace }}" = "true" ]; then
+            CODESPACE_FLAG="-s"
+          fi
+          ${{ github.workspace }}/.github/workflows/create-wth-template.sh -p ${{ github.workspace }} -c ${{ github.event.inputs.numberOfChallenges}} -n ${{ github.event.inputs.hackName }} -v -d $CODESPACE_FLAG
       - name: Push branch
         run: |
           git add *
+          if [ "${{ github.event.inputs.includeCodespace }}" = "true" ]; then
+            git add .devcontainer
+          fi
           git commit -m 'Created WhatTheHack template stub'
           git push -u origin ${{ env.BRANCH_NAME }}
 

--- a/.github/workflows/create-wth-template.sh
+++ b/.github/workflows/create-wth-template.sh
@@ -6,13 +6,14 @@ IFS=$'\n\t'
 declare -r templateDirectoryName="000-HowToHack"
 
 Help() {
-   echo "Syntax: createWthTemplate [-c|d|h|n|p|v]"
+   echo "Syntax: createWthTemplate [-c|d|h|n|p|s|v]"
    echo "options:"
    echo "c     How many challenges to stub out."
    echo "d     Delete existing directory with same name."
    echo "h     Print this Help."
    echo "n     Name of the new WhatTheHack. This must be a valid directory name"
    echo "p     Path to where to create new WhatTheHack directory."
+   echo "s     Include GitHub Codespace configuration."
    echo "v     Verbose mode."
    echo
 }
@@ -53,6 +54,41 @@ CreateDirectoryStructure() {
   
   #add a file to allow git to store an "empty" directory
   touch $rootPath/Student/Resources/.gitkeep
+}
+
+CreateCodespaceConfig() {
+  local -r templateFile="$pathToTemplateDirectory/devcontainerTEMPLATE.json"
+
+  if $verbosityArg; then
+    echo "Creating Codespace configuration for $wthDirectoryName..."
+  fi
+
+  # Create the Student/Resources/.devcontainer directory
+  mkdir -p "$rootPath/Student/Resources/.devcontainer"
+
+  # Remove the .gitkeep since the directory is no longer empty
+  rm -f "$rootPath/Student/Resources/.gitkeep"
+
+  # Create Student/Resources copy: update "name" only, leave workspace lines commented
+  sed -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
+    "$templateFile" > "$rootPath/Student/Resources/.devcontainer/devcontainer.json"
+
+  if $verbosityArg; then
+    echo "Created $rootPath/Student/Resources/.devcontainer/devcontainer.json"
+  fi
+
+  # Create root-level .devcontainer/xxx-HackName directory
+  mkdir -p "$pathArg/.devcontainer/$wthDirectoryName"
+
+  # Create root-level copy: update "name", uncomment and populate workspaceFolder/workspaceMount
+  sed -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
+    -e "s|// \"workspaceFolder\": \"/workspace/XXX-HackathonName/Student/Resources\"|\"workspaceFolder\": \"/workspace/$wthDirectoryName/Student/Resources\"|" \
+    -e "s|// \"workspaceMount\": \"source=\${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached\"|\"workspaceMount\": \"source=\${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached\"|" \
+    "$templateFile" > "$pathArg/.devcontainer/$wthDirectoryName/devcontainer.json"
+
+  if $verbosityArg; then
+    echo "Created $pathArg/.devcontainer/$wthDirectoryName/devcontainer.json"
+  fi
 }
 
 PreprocessTemplateFile() {
@@ -244,8 +280,9 @@ CreateChallengesAndSolutions() {
 # Main program
 declare verbosityArg=false
 declare deleteExistingDirectoryArg=false
+declare codespaceArg=false
 
-while getopts ":c:dhn:p:v" option; do
+while getopts ":c:dhn:p:sv" option; do
   case $option in
     c) numberOfChallengesArg=${OPTARG};;
     d) deleteExistingDirectoryArg=true;;
@@ -253,6 +290,7 @@ while getopts ":c:dhn:p:v" option; do
        exit;;
     n) nameOfHackArg=${OPTARG};;
     p) pathArg=${OPTARG};;
+    s) codespaceArg=true;;
     v) verbosityArg=true
   esac
 done
@@ -275,3 +313,7 @@ CreateDirectoryStructure $deleteExistingDirectoryArg
 CreateHackDescription $numberOfChallengesArg
 
 CreateChallengesAndSolutions $numberOfChallengesArg
+
+if $codespaceArg; then
+  CreateCodespaceConfig
+fi

--- a/.github/workflows/create-wth-template.sh
+++ b/.github/workflows/create-wth-template.sh
@@ -66,9 +66,6 @@ CreateCodespaceConfig() {
   # Create the Student/Resources/.devcontainer directory
   mkdir -p "$rootPath/Student/Resources/.devcontainer"
 
-  # Remove the .gitkeep since the directory is no longer empty
-  rm -f "$rootPath/Student/Resources/.gitkeep"
-
   # Create Student/Resources copy: update "name" only, leave workspace lines commented
   sed -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
     "$templateFile" > "$rootPath/Student/Resources/.devcontainer/devcontainer.json"

--- a/.github/workflows/create-wth-template.sh
+++ b/.github/workflows/create-wth-template.sh
@@ -66,9 +66,16 @@ CreateCodespaceConfig() {
   # Create the Student/Resources/.devcontainer directory
   mkdir -p "$rootPath/Student/Resources/.devcontainer"
 
-  # Create Student/Resources copy: update "name" only, leave workspace lines commented
-  sed -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
-    "$templateFile" > "$rootPath/Student/Resources/.devcontainer/devcontainer.json"
+  # Prepare the brief comment header for Action-created copies
+  local -r briefComment="// Customize this devcontainer.json with features and extensions for your hackathon.\n// See: https://containers.dev/implementors/json_reference/\n"
+
+  # Create Student/Resources copy: strip template instructions, update "name", leave workspace lines commented
+  sed -e '/TEMPLATE_INSTRUCTIONS_START/,/TEMPLATE_INSTRUCTIONS_END/d' \
+    -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
+    "$templateFile" | sed "1i\\
+// Customize this devcontainer.json with features and extensions for your hackathon.\\
+// See: https://containers.dev/implementors/json_reference/" \
+    > "$rootPath/Student/Resources/.devcontainer/devcontainer.json"
 
   if $verbosityArg; then
     echo "Created $rootPath/Student/Resources/.devcontainer/devcontainer.json"
@@ -77,11 +84,15 @@ CreateCodespaceConfig() {
   # Create root-level .devcontainer/xxx-HackName directory
   mkdir -p "$pathArg/.devcontainer/$wthDirectoryName"
 
-  # Create root-level copy: update "name", uncomment and populate workspaceFolder/workspaceMount
-  sed -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
+  # Create root-level copy: strip template instructions, update "name", uncomment and populate workspace settings
+  sed -e '/TEMPLATE_INSTRUCTIONS_START/,/TEMPLATE_INSTRUCTIONS_END/d' \
+    -e "s/\"xxx-HackName\"/\"$wthDirectoryName\"/" \
     -e "s|// \"workspaceFolder\": \"/workspace/XXX-HackathonName/Student/Resources\"|\"workspaceFolder\": \"/workspace/$wthDirectoryName/Student/Resources\"|" \
     -e "s|// \"workspaceMount\": \"source=\${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached\"|\"workspaceMount\": \"source=\${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached\"|" \
-    "$templateFile" > "$pathArg/.devcontainer/$wthDirectoryName/devcontainer.json"
+    "$templateFile" | sed "1i\\
+// Customize this devcontainer.json with features and extensions for your hackathon.\\
+// See: https://containers.dev/implementors/json_reference/" \
+    > "$pathArg/.devcontainer/$wthDirectoryName/devcontainer.json"
 
   if $verbosityArg; then
     echo "Created $pathArg/.devcontainer/$wthDirectoryName/devcontainer.json"

--- a/000-HowToHack/devcontainerTEMPLATE.json
+++ b/000-HowToHack/devcontainerTEMPLATE.json
@@ -1,16 +1,27 @@
+// TEMPLATE_INSTRUCTIONS_START
 // This is a template devcontainer.json for What The Hack hackathons.
 // It provides a baseline configuration for GitHub Codespaces and VS Code Dev Containers.
 //
-// Instructions for hackathon authors:
-// 1. Copy this file to your hack's .devcontainer folder as devcontainer.json
-// 2. Uncomment and update "workspaceFolder" and "workspaceMount" with your hack's folder name
-// 3. Add any additional features or extensions specific to your hackathon
-//
+// Instructions for hackathon authors adding Codespace support to an existing hack:
+// 1. Copy this file to the following two locations:
+//    a. Your hack's /Student/Resources/.devcontainer/ folder as devcontainer.json
+//    b. Under the root-level /.devcontainer/ folder, create a folder with the same
+//       name as your hack's folder (e.g., "xxx-HackName") and add a copy there.
+// 2. In both copies, update the "name" field with your hack's folder name.
+// 3. Only in the root-level /.devcontainer/xxx-HackName/ copy, uncomment and update
+//    "workspaceFolder" and "workspaceMount" with your hack's folder name.
+// 4. Add any additional features or extensions specific to your hackathon.
+//    See: https://containers.dev/implementors/json_reference/
+// TEMPLATE_INSTRUCTIONS_END
 {
+  // TEMPLATE_INSTRUCTIONS_START
   // Update "name" with your hack's number and name (e.g., "042-SAPOnAzure")
+  // TEMPLATE_INSTRUCTIONS_END
   "name": "xxx-HackName",
   "image": "mcr.microsoft.com/devcontainers/universal:2",
+  // TEMPLATE_INSTRUCTIONS_START
   // Uncomment and update the following two properties with your hack's folder name:
+  // TEMPLATE_INSTRUCTIONS_END
   // "workspaceFolder": "/workspace/XXX-HackathonName/Student/Resources",
   // "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "hostRequirements": {


### PR DESCRIPTION
## Summary

This PR adds an optional "Include a GitHub Codespace configuration?" checkbox to the **Create New Hack** GitHub Action workflow. When an author enables this option, the action automatically scaffolds the devcontainer configuration in both required locations.

## Changes

### Workflow (`create-new-hack.yml`)
- Added `includeCodespace` boolean input to the workflow dispatch form
- Passes `-s` flag to the shell script when enabled
- Conditionally stages the root-level `.devcontainer` folder

### Shell script (`create-wth-template.sh`)
- Added `-s` flag and `CreateCodespaceConfig()` function
- When invoked, creates:
  - `/Student/Resources/.devcontainer/devcontainer.json` — workspace lines remain commented (for local devcontainer use)
  - `/.devcontainer/xxx-HackName/devcontainer.json` — workspace lines uncommented and populated (for GitHub Codespaces)
- Strips template-only instruction comments from copies and inserts a brief "customize" comment with a link to the devcontainer reference docs

### Template (`000-HowToHack/devcontainerTEMPLATE.json`)
- Updated comments with full instructions for authors manually adding Codespace support to existing hacks
- Instructions wrapped in `TEMPLATE_INSTRUCTIONS_START/END` markers so the action can strip them when creating copies

## Behavior

- **Without the checkbox**: Action works exactly as before (no breaking changes)
- **With the checkbox**: Both devcontainer.json files are created with appropriate content for their location